### PR TITLE
(CAT-1841) Update docs with current structures

### DIFF
--- a/style_guide.md
+++ b/style_guide.md
@@ -72,10 +72,51 @@ Manifests:
 
 
 -   Should not exceed a 140-character line width, except where such a limit would be impractical.
-
+-   May align hash rockets \(`=>`\) within blocks of attributes, one space after the longest resource key, arranging hashes for maximum readability first.
+-   Should not leave any empty lines between class declaration and the first declared resource.
 -   Should leave one empty line between resources, except when using dependency chains.
 
--   May align hash rockets \(`=>`\) within blocks of attributes, one space after the longest resource key, arranging hashes for maximum readability first.
+    Good:
+
+    ```
+    class ntp::install {
+      package { $ntp::package_name:
+        ...
+      }
+
+      exec {
+        ...
+      }
+    }
+    ```
+
+    Bad: Empty line after class declaration:
+
+    ```
+    class ntp::install {
+
+      package { $ntp::package_name:
+        ...
+      }
+
+      exec {
+        ...
+      }
+    }
+    ```
+
+    Bad: No empty line between resource declarations:
+
+    ```
+    class ntp::install {
+      package { $ntp::package_name:
+        ...
+      }
+      exec {
+        ...
+      }
+    }
+    ```
 
 
 ### Arrays and hashes


### PR DESCRIPTION
Prior to this commit the documentation did not properly define the rules regarding empty lines within classes. This resulted in customer escalations. As a result, we decided to update the documentation to implement the missing rules.