### PR TITLE
Pin theme version to known good

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-remote_theme: chrisrhymes/bulma-clean-theme
+remote_theme: chrisrhymes/bulma-clean-theme@v0.14.0
 footer_menu: footer
 defaults:
   -


### PR DESCRIPTION
The theme has updated past what the default github page build can
support. This means we need to pin to v0.14.0.

https://github.com/chrisrhymes/bulma-clean-theme#v0x
